### PR TITLE
Add footer legal information and pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,11 @@
       </div>
     </main>
     <footer>
-      <p>&copy; 2024 Stylish Reservation System</p>
+      <div class="footer-links">
+        <a href="privacy-policy.html">Privacy Policy</a>
+        <a href="terms-of-service.html">Terms of Service</a>
+      </div>
+      <p>&copy; 2025 Yoyaku. All Rights Reserved.</p>
     </footer>
   </div>
   <script src="app.js"></script>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Yoyaku</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Privacy Policy</h1>
+      <p>How we handle your personal information</p>
+    </header>
+    <main>
+      <div class="legal-content">
+        <h2>Information Collection</h2>
+        <p>We collect information you provide directly to us, such as when you create an account, make a reservation, or contact us for support.</p>
+        
+        <h2>Use of Information</h2>
+        <p>We use the information we collect to provide, maintain, and improve our services, process reservations, and communicate with you.</p>
+        
+        <h2>Information Sharing</h2>
+        <p>We do not sell, trade, or otherwise transfer your personal information to third parties without your consent, except as described in this policy.</p>
+        
+        <h2>Data Security</h2>
+        <p>We implement appropriate security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction.</p>
+        
+        <h2>Contact Us</h2>
+        <p>If you have any questions about this Privacy Policy, please contact us through our reservation system.</p>
+        
+        <p class="last-updated">Last updated: May 26, 2025</p>
+      </div>
+      <div class="navigation">
+        <a href="index.html" class="btn-secondary">Back to Reservations</a>
+      </div>
+    </main>
+    <footer>
+      <div class="footer-links">
+        <a href="privacy-policy.html">Privacy Policy</a>
+        <a href="terms-of-service.html">Terms of Service</a>
+      </div>
+      <p>&copy; 2025 Yoyaku. All Rights Reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -123,6 +123,52 @@ footer {
   padding-top: 24px;
 }
 
+.footer-links {
+  margin-bottom: 12px;
+}
+
+.footer-links a {
+  color: #64748b;
+  text-decoration: none;
+  margin: 0 12px;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.footer-links a:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.legal-content {
+  text-align: left;
+  line-height: 1.6;
+}
+
+.legal-content h2 {
+  color: #2563eb;
+  font-size: 1.3rem;
+  margin-top: 24px;
+  margin-bottom: 12px;
+}
+
+.legal-content p {
+  color: #334155;
+  margin-bottom: 16px;
+}
+
+.legal-content .last-updated {
+  font-style: italic;
+  color: #64748b;
+  font-size: 0.9rem;
+  margin-top: 32px;
+}
+
+.navigation {
+  text-align: center;
+  margin-top: 32px;
+}
+
 @media (max-width: 600px) {
   .container {
     padding: 18px 6px 12px 6px;

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service - Yoyaku</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Terms of Service</h1>
+      <p>Terms and conditions for using our service</p>
+    </header>
+    <main>
+      <div class="legal-content">
+        <h2>Acceptance of Terms</h2>
+        <p>By accessing and using this reservation system, you accept and agree to be bound by the terms and provision of this agreement.</p>
+        
+        <h2>Use License</h2>
+        <p>Permission is granted to temporarily use this reservation system for personal, non-commercial transitory viewing only.</p>
+        
+        <h2>Disclaimer</h2>
+        <p>The materials on this website are provided on an 'as is' basis. We make no warranties, expressed or implied, and hereby disclaim all other warranties.</p>
+        
+        <h2>Limitations</h2>
+        <p>In no event shall Yoyaku or its suppliers be liable for any damages arising out of the use or inability to use the materials on this website.</p>
+        
+        <h2>Accuracy of Materials</h2>
+        <p>The materials appearing on this website could include technical, typographical, or photographic errors. We do not warrant that any of the materials are accurate, complete, or current.</p>
+        
+        <h2>Modifications</h2>
+        <p>We may revise these terms of service at any time without notice. By using this website, you are agreeing to be bound by the then current version of these terms of service.</p>
+        
+        <p class="last-updated">Last updated: May 26, 2025</p>
+      </div>
+      <div class="navigation">
+        <a href="index.html" class="btn-secondary">Back to Reservations</a>
+      </div>
+    </main>
+    <footer>
+      <div class="footer-links">
+        <a href="privacy-policy.html">Privacy Policy</a>
+        <a href="terms-of-service.html">Terms of Service</a>
+      </div>
+      <p>&copy; 2025 Yoyaku. All Rights Reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Add footer legal information to the landing page

- Create Privacy Policy page with comprehensive content
- Create Terms of Service page with detailed terms
- Update main page footer with links to both legal pages
- Add copyright notice "© 2025 Yoyaku. All Rights Reserved."
- Style footer links and legal content with consistent design

Fixes #2

Generated with [Claude Code](https://claude.ai/code)